### PR TITLE
feat/fix: apply NAT IP only AWS to LOKI request by Caddy

### DIFF
--- a/.github/workflows/update-stage.yml
+++ b/.github/workflows/update-stage.yml
@@ -21,25 +21,29 @@ jobs:
         GF_SMTP_FROM_ADDRESS = ${{ secrets.FROM_ADDRESS }}
         EOF
 
-    - name: Check if log containers are running
-      id: check-container
+    - name: Check if Caddy containers are running
+      id: check-caddy-container
       run: |
         {
           echo 'stdout<<EOF'
-          docker compose --profile log ps -q
+          docker compose --profile caddy ps -q
           echo EOF
         } >> "$GITHUB_OUTPUT"
-    
-    - name: Set up Caddy
+
+    - name: when caddy container down, caddy up
+      if: steps.check-caddy-container.outputs.stdout == ''
+      run: |
+        docker compose --profile caddy up -d --no-recreate
+
+    - name: Copy Caddyfile into Caddy Container
       env:
         AWS_REQ_IP: ${{ secrets.AWS_NAT_IP }}
       run: |
-        docker compose --profile caddy up -d
-
-    - name: Initialize containers
-      if: steps.check-container.outputs.stdout == ''
+        docker cp ./Caddyfile caddy:/etc/caddy/Caddyfile
+    
+    - name: Gracefully reload Caddy
       run: |
-        docker compose --profile log up -d --no-recreate
+        docker exec -w /etc/caddy caddy caddy reload
         
     - name: Run Docker Compose Of Log
       run: |

--- a/.github/workflows/update-stage.yml
+++ b/.github/workflows/update-stage.yml
@@ -21,7 +21,7 @@ jobs:
         GF_SMTP_FROM_ADDRESS = ${{ secrets.FROM_ADDRESS }}
         EOF
 
-    - name: Check if containers are running
+    - name: Check if log containers are running
       id: check-container
       run: |
         {
@@ -29,24 +29,19 @@ jobs:
           docker compose --profile log ps -q
           echo EOF
         } >> "$GITHUB_OUTPUT"
+    
+    - name: Set up Caddy
+      env:
+        AWS_REQ_IP: ${{ secrets.AWS_NAT_IP }}
+      run: |
+        docker compose --profile caddy up -d
 
     - name: Initialize containers
       if: steps.check-container.outputs.stdout == ''
       run: |
-        docker compose --profile caddy up -d --no-recreate
         docker compose --profile log up -d --no-recreate
         
-    - name: Run Docker Compose
+    - name: Run Docker Compose Of Log
       run: |
         docker compose --profile log up -d
     
-    - name: Copy Caddyfile into Caddy Container
-      run: |
-        docker cp ./Caddyfile caddy:/etc/caddy/Caddyfile
-      
-    - name: Gracefully reload Caddy
-      run: |
-        docker exec -w /etc/caddy caddy caddy reload
-    
-    - name: Remove unused docker storages
-      run: docker system prune -a -f --volumes

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,5 +1,8 @@
 grafana.codedang.com {
 	handle /lokiaws/* {
+		@blocked not remote_ip {$AWS_REQ_IP}
+		respond @blocked "Forbidden" 403
+
 		uri strip_prefix /lokiaws
 		reverse_proxy 127.0.0.1:3100
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,6 @@ services:
     image: caddy:2.7.6-alpine
     container_name: caddy
     restart: always
-    volumes: 
-      - $PWD/Caddyfile:/etc/caddy/Caddyfile
-    environment: 
-      - AWS_REQ_IP: ${AWS_REQ_IP}
     ports:
       - "80:80"
       - "443:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,10 @@ services:
     image: caddy:2.7.6-alpine
     container_name: caddy
     restart: always
+    volumes: 
+      - $PWD/Caddyfile:/etc/caddy/Caddyfile
+    environment: 
+      - AWS_REQ_IP: ${AWS_REQ_IP}
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
closes #5 
1. codedang AWS에서 오는 요청만 LOKI에서 수집하기 위해 Caddy에서 특정 NAT IP만 프록시하도록 설정하였습니다.
2. github action flow 를 보완하였습니다.
- Caddy를 reload하는 과정은 static frontend file mount가 정상적으로 작동하지 않았을 때 해결하는 과정이므로 불필요하다고 생각합니다.
- 사용하지 않는 volume을 삭제하는 과정은 추후 로그 분석시 이전 log가 삭제될 가능성을 염두하였을 때 불필요하다고 생각합니다.
- container가 running인지 확인하는 과정은 log container에 국한되므로, 이를 분리합니다.