### PR TITLE
feat: setup caddy reverse-proxy for sentry

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -16,3 +16,7 @@ grafana.codedang.com {
 		reverse_proxy 127.0.0.1:3000
 	}
 }
+
+sentry.codedang.com {
+        reverse_proxy 127.0.0.1:9876
+}


### PR DESCRIPTION
Sentry를 위해 Caddyfile 수정해뒀습니다
Sentry 포트 번호는 127.0.0.1:9876임다