### PR TITLE
fix(infra): change Caddyfile for resolving handle path and leaving logs

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,8 @@
 grafana.codedang.com {
+	log {
+		format console
+	}
+	
 	handle /lokiaws/* {
 		@blocked not remote_ip {$AWS_REQ_IP}
 		respond @blocked "Forbidden" 403

--- a/Caddyfile
+++ b/Caddyfile
@@ -24,7 +24,7 @@ grafana.codedang.com {
 		}
 	}
 
-	handle /prometheus {
+	handle /prometheus/* {
 		uri strip_prefix /prometheus
 		reverse_proxy 127.0.0.1:9090
 	}


### PR DESCRIPTION
- prometheus의 handle path가 잘못되어있어 수정하였습니다. (* 특수문자를 url 끝에 추가함)
- 현재 컨테이너들이 외부에서 접속이 안되는 문제의 원인을 파악하기 위해 Caddy가 error뿐만이 아닌 모든 log를 console에 출력할 수 있도록 설정하였습니다.