### PR TITLE
fix: remove docker networks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,5 @@
 version: "3.8"
 
-networks:
-  loki:
-
 services:
   caddy:
     profiles: ["caddy"]
@@ -23,8 +20,6 @@ services:
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
-    networks:
-      - loki
     ports:
       - "9000:9000"
       - "9001:9001"
@@ -36,8 +31,6 @@ services:
     image: minio/mc
     volumes:
       - minio_data_volume:/data
-    networks:
-      - loki
     depends_on:
       - minio
     entrypoint: >
@@ -64,8 +57,6 @@ services:
     volumes:
       - "$PWD/config/loki/loki-config-test.yml:/etc/loki/loki-config.yml"
     command: -config.file=/etc/loki/loki-config.yml -config.expand-env=true
-    networks:
-      - loki
 
   loki-stage:
     profiles: ["log"]
@@ -79,8 +70,6 @@ services:
     volumes:
       - "$PWD/config/loki/loki-config-stage.yml:/etc/loki/loki-config.yml"
     command: -config.file=/etc/loki/loki-config.yml -config.expand-env=true
-    networks:
-      - loki
 
   loki-aws:
     profiles: ["log"]
@@ -94,8 +83,6 @@ services:
     volumes:
       - "$PWD/config/loki/loki-config-aws.yml:/etc/loki/loki-config.yml"
     command: -config.file=/etc/loki/loki-config.yml -config.expand-env=true
-    networks:
-      - loki
 
   prometheus:
     profiles: ["metric"]
@@ -140,8 +127,6 @@ services:
     volumes:
       - "grafana_storage:/var/lib/grafana"
       - "$PWD/config/grafana/grafana.ini:/etc/grafana/grafana.ini"
-    networks:
-      - loki
 
 volumes:
   grafana_storage: {}


### PR DESCRIPTION
close #32 

Docker 의 network를 변경하였습니다. 
caddy의 경우 host로 유지했고, 나머지 service들은 default bridge 모드로 설정하였습니다. 