### PR TITLE
hotfix: fix docker container dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     network_mode: host
 
   minio:
-    profiles: ["log"]
+    profiles: ["log", "trace"]
     container_name: minio
     image: minio/minio:latest
     volumes:


### PR DESCRIPTION
tempo 컨테이너와 minio 컨테이너간의 의존문제를 해결합니다. 