### PR TITLE
feat(infra): set docker volume mount to prometheus container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,7 @@ services:
       - "9090:9090"
     volumes:
       - "$PWD/config/prometheus/prometheus-config.yml:/etc/prometheus/prometheus-config.yml"
+      - prometheus_data_volume:/prometheus
     command: 
       - '--config.file=/etc/prometheus/prometheus-config.yml'
       - '--storage.tsdb.path=/prometheus'
@@ -151,3 +152,4 @@ services:
 volumes:
   grafana_storage: {}
   minio_data_volume:
+  prometheus_data_volume:


### PR DESCRIPTION
Close #39 

Prometheus 컨테이너의 데이터 보존성을 향상시키기 위해 Prometheus 컨테이너에 대한 도커 볼륨 마운트를 추가하였습니다.
컨테이너 재시작이나 재배포 시에도 Prometheus 데이터가 유실되지 않도록 합니다.
호스트 디렉토리와 연결하지 않고, docker volume을 생성하도록 docker-compose.yml 파일을 수정하였습니다.
