### PR TITLE
chore(infra): update trace confing

### DIFF
--- a/config/tempo/tempo.yml
+++ b/config/tempo/tempo.yml
@@ -20,6 +20,7 @@ distributor:
 
 ingester:
   max_block_duration: 5m               # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally
+  flush_all_on_shutdown: true
 
 compactor:
   compaction:

--- a/config/tempo/tempo.yml
+++ b/config/tempo/tempo.yml
@@ -26,15 +26,6 @@ compactor:
     block_retention: 1h                # overall Tempo trace retention. set for demo purposes
 
 # metrics_generator:
-#   registry:
-#     external_labels:
-#       source: tempo
-#       cluster: docker-compose
-#   storage:
-#     path: /tmp/tempo/generator/wal
-#     remote_write:
-#       - url: http://prometheus:9090/api/v1/write
-#         send_exemplars: true
 
 storage:
   trace:
@@ -47,8 +38,3 @@ storage:
       access_key: ${MINIO_ROOT_USER}
       secret_key: ${MINIO_ROOT_PASSWORD}
       insecure: true
-
-overrides:
-  defaults:
-    metrics_generator:
-      processors: [service-graphs, span-metrics] # enables metrics generator

--- a/config/tempo/tempo.yml
+++ b/config/tempo/tempo.yml
@@ -23,7 +23,7 @@ ingester:
 
 compactor:
   compaction:
-    block_retention: 1h                # overall Tempo trace retention. set for demo purposes
+    block_retention: 336h              # Duration to keep blocks. Default is 14 days
 
 # metrics_generator:
 


### PR DESCRIPTION
Close #43 

설정 사항
- 저장 기간 : 기존 1h 에서 336h(14일)로 연장했습니다. 
- flush : ingester 가 종료될 때, 들고있는 data를 flush하도록 강제하였습니다. 