### PR TITLE
fix(infra): start and restart all containers except for start-up containers

### DIFF
--- a/.github/workflows/update-stage.yml
+++ b/.github/workflows/update-stage.yml
@@ -36,23 +36,18 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
 
-      - name: when initial containers are not running, start all containers
+      - name: when initial containers are not running, start start-up containers
         if: steps.check-start-up-container.outputs.stdout == ''
         run: >
-          docker compose --profile start-up --profile log 
-          --profile trace --profile metric up -d
+          docker compose --profile start-up up -d
 
-      - name: Restart containers for Log (Loki, Minio)
+      - name: Start all containers except for start-up
         run: |
-          docker compose --profile log restart
+          docker compose --profile log --profile trace --profile metric up -d
 
-      - name: Restart containers Of Trace (Tempo, Minio)
+      - name: Restart all containers except for start-up
         run: |
-          docker compose --profile trace restart
-
-      - name: Restart containers for Metric (Prometheus)
-        run: |
-          docker compose --profile metric restart
+          docker compose --profile log --profile trace --profile metric restart
 
       - name: Set Caddyfile Environment Variables
         run: |


### PR DESCRIPTION
Close #52 
- start-up 프로파일이 명시된 컨테이너가 실행 중이든 아니든 start-up 컨테이너들을 제외한 모든 컨테이너들을 항상 시작, 재시작하도록 하였습니다.
- 시작: `docker-compose up -d` 
- 재시작: `docker-compose restart`
- 항상 시작을 해야하는 이유: restart만 하게 된다면, 새로운 컨테이너가 추가되었을 때 실행되지 않습니다.
- 항상 재시작을 해야하는 이유: up만 하게 된다면, `docker-compose.yml` 이 아닌 다른 설정파일/소스코드 등이 수정되었을 때 수정사항이 반영되지 않습니다.
- 여기서 마지막으로! 짚고넘어가는 start-up은 항상 시작을 하면 안되는 이유
: start-up 프로파일이 명시된 컨테이너 중 하나는 Caddy 컨테이너인데요. Caddy 컨테이너를 시작(`docker compose up`)하면 Let's Encrypt를 통해 인증서를 자동으로 발급받습니다. 하지만 횟수 제한이 있어 무제한으로 발급받을 수 없습니다. 이를 방지하기 위해, Caddy 컨테이너가 없을 때만 시작하도록 설정하였습니다.

