### PR TITLE
fix(infra): delete start-up profile and add caddy profile

### DIFF
--- a/.github/workflows/update-stage.yml
+++ b/.github/workflows/update-stage.yml
@@ -27,25 +27,25 @@ jobs:
 
           EOF
 
-      - name: Check if initial containers are running
-        id: check-start-up-container
+      - name: Check if caddy container is running
+        id: check-caddy-container
         run: |
           {
             echo 'stdout<<EOF'
-            docker compose --profile start-up ps -q
+            docker compose --profile caddy ps -q
             echo EOF
           } >> "$GITHUB_OUTPUT"
 
-      - name: when initial containers are not running, start start-up containers
-        if: steps.check-start-up-container.outputs.stdout == ''
+      - name: when caddy container is not running, start caddy container
+        if: steps.check-caddy-container.outputs.stdout == ''
         run: >
-          docker compose --profile start-up up -d
+          docker compose --profile caddy up -d
 
-      - name: Start all containers except for start-up
+      - name: Start all containers except for caddy
         run: |
           docker compose --profile log --profile trace --profile metric up -d
 
-      - name: Restart all containers except for start-up
+      - name: Restart all containers except for caddy
         run: |
           docker compose --profile log --profile trace --profile metric restart
 

--- a/.github/workflows/update-stage.yml
+++ b/.github/workflows/update-stage.yml
@@ -36,23 +36,18 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
 
-      - name: when initial containers are not running, start all containers
+      - name: when initial containers are not running, start start-up containers
         if: steps.check-start-up-container.outputs.stdout == ''
         run: >
-          docker compose --profile start-up --profile log 
-          --profile trace --profile metric up -d
+          docker compose --profile start-up up -d
 
-      - name: Restart containers for Log (Loki, Minio)
+      - name: Start all containers except for start-up
         run: |
-          docker compose --profile log restart
+          docker compose --profile log --profile trace --profile metric up -d
 
-      - name: Restart containers Of Trace (Tempo, Minio)
+      - name: Restart all containers except for start-up
         run: |
-          docker compose --profile trace restart
-
-      - name: Restart containers for Metric (Prometheus)
-        run: |
-          docker compose --profile metric restart
+          docker compose --profile log --profile trace --profile metric restart
 
       - name: Set Caddyfile Environment Variables
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   caddy:
-    profiles: ["start-up"]
+    profiles: ["caddy"]
     image: caddy:2.7.6-alpine
     container_name: caddy
     restart: always
@@ -12,7 +12,7 @@ services:
     network_mode: host
 
   minio:
-    profiles: ["start-up"] 
+    profiles: ["log", "trace"] 
     container_name: minio
     image: minio/minio:latest
     volumes:
@@ -27,7 +27,7 @@ services:
     shm_size: "1gb"
 
   createbuckets:
-    profiles: ["start-up", "log", "trace"]
+    profiles: ["log", "trace"]
     image: minio/mc
     volumes:
       - minio_data_volume:/data
@@ -152,7 +152,7 @@ services:
     restart: always
 
   grafana:
-    profiles: ["start-up"]
+    profiles: ["log", "trace", "metric"]
     image: grafana/grafana:latest
     env_file:
       - .env


### PR DESCRIPTION
- docker-compose.yml 파일에서 start-up 프로파일을 제거하고, caddy 프로파일로 변경하였습니다.
- 기존에 start-up 프로파일에 caddy, minio, createbuckets, grafana 컨테이너들이 지정되어있었는데, 분리하였습니다.
- 따라서, caddy 컨테이너만 실행되고 있지 않을 시, 실행되고 나머지 모든 컨테이너들은 실행여부와 상관없이 실행, 재시작됩니다.