### PR TITLE
fix: resolve old dashboard queries

### DIFF
--- a/backends/loki/loki-config.yml
+++ b/backends/loki/loki-config.yml
@@ -5,6 +5,11 @@ server:
   grpc_listen_port: 0
   log_level: info
 
+distributor:
+  otlp_config:
+    default_resource_attributes_as_index_labels:
+      - "service.environment"
+
 common:
   instance_addr: 127.0.0.1
   path_prefix: /tmp/loki

--- a/collectors/otel-collector/config.yml
+++ b/collectors/otel-collector/config.yml
@@ -32,6 +32,8 @@ exporters:
 
   prometheus:
     endpoint: "0.0.0.0:8889"
+    resource_to_telemetry_conversion:
+      enabled: true
 
   otlp/trace:
     endpoint: tempo:4317

--- a/collectors/otel-collector/config.yml
+++ b/collectors/otel-collector/config.yml
@@ -44,15 +44,15 @@ service:
   pipelines:
     logs:
       receivers: [otlp]
-      processors: []
+      processors: [batch]
       exporters: [otlphttp/logs]
     metrics:
       receivers: [otlp]
-      processors: []
+      processors: [batch]
       exporters: [prometheus]
     traces:
       receivers: [otlp]
-      processors: []
+      processors: [batch]
       exporters: [otlp/trace]
 
   # Collector 자체 모니터링을 위한 설정

--- a/grafana/provisioning/dashboards/AWS/LOG.json
+++ b/grafana/provisioning/dashboards/AWS/LOG.json
@@ -19,7 +19,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 18,
+  "id": 7,
   "links": [],
   "liveNow": true,
   "panels": [
@@ -39,8 +39,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -103,6 +102,10 @@
         "uid": "loki"
       },
       "description": "시스템 운영에 치명적일 수 있는 오류만을 출력",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 5,
         "w": 19,
@@ -142,6 +145,10 @@
         "uid": "loki"
       },
       "description": "AWS 서버의 ECS_API - Client 에서 오는 로그입니다! \n(Uptime Kuma에서 오는 리퀘스트는 제거했습니다.)",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 8,
         "w": 22,
@@ -151,6 +158,7 @@
       "id": 10,
       "options": {
         "dedupStrategy": "none",
+        "enableInfiniteScrolling": false,
         "enableLogDetails": true,
         "prettifyLogMessage": false,
         "showCommonLabels": false,
@@ -159,15 +167,16 @@
         "sortOrder": "Descending",
         "wrapLogMessage": false
       },
-      "pluginVersion": "10.2.3",
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
             "type": "loki",
             "uid": "loki"
           },
+          "direction": "backward",
           "editorMode": "builder",
-          "expr": "{container_name=~\".*Client-Api.*\"} |= `info` !~ `(?i)Uptime-Kuma` | pattern `<_>=<ec2_instance_id> log=<log>` | logfmt --strict --keep-empty log | line_format `{{.log}}`",
+          "expr": "{service_name=\"CLIENT-API\"}",
           "queryType": "range",
           "refId": "A"
         }
@@ -181,6 +190,10 @@
         "uid": "loki"
       },
       "description": "AWS 서버의 ECS_API - Admin 에서 오는 로그입니다! \n(Uptime Kuma에서 오는 리퀘스트는 제거했습니다.)",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 8,
         "w": 22,
@@ -220,6 +233,10 @@
         "uid": "loki"
       },
       "description": "AWS 서버의 IRIS 에서 오는 로그입니다! ",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 8,
         "w": 22,
@@ -254,8 +271,9 @@
       "type": "logs"
     }
   ],
+  "preload": false,
   "refresh": "",
-  "schemaVersion": 39,
+  "schemaVersion": 41,
   "tags": ["deploy-server", "log"],
   "templating": {
     "list": []
@@ -264,12 +282,9 @@
     "from": "now-12h",
     "to": "now"
   },
-  "timepicker": {
-    "hidden": false
-  },
+  "timepicker": {},
   "timezone": "",
   "title": "LOG",
   "uid": "f0149ec2-7bf4-4d84-ab7a-131d330149fa",
-  "version": 18,
-  "weekStart": ""
+  "version": 2
 }

--- a/grafana/provisioning/dashboards/AWS/LOG.json
+++ b/grafana/provisioning/dashboards/AWS/LOG.json
@@ -19,7 +19,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 7,
+  "id": 24,
   "links": [],
   "liveNow": true,
   "panels": [
@@ -39,7 +39,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -71,7 +72,7 @@
         "showThresholdMarkers": false,
         "sizing": "auto"
       },
-      "pluginVersion": "12.0.1",
+      "pluginVersion": "11.5.0",
       "targets": [
         {
           "datasource": {
@@ -124,7 +125,7 @@
         "sortOrder": "Descending",
         "wrapLogMessage": false
       },
-      "pluginVersion": "12.0.1",
+      "pluginVersion": "11.5.0",
       "targets": [
         {
           "datasource": {
@@ -168,13 +169,14 @@
         "sortOrder": "Descending",
         "wrapLogMessage": false
       },
-      "pluginVersion": "12.0.1",
+      "pluginVersion": "11.5.0",
       "targets": [
         {
           "datasource": {
             "type": "loki",
             "uid": "loki"
           },
+          "direction": "backward",
           "editorMode": "builder",
           "expr": "{container_name=~\".*Client-Api.*\"} |= `info` !~ `(?i)Uptime-Kuma` | pattern `<_>=<ec2_instance_id> log=<log>` | logfmt --strict --keep-empty log | line_format `{{.log}}`",
           "queryType": "range",
@@ -212,7 +214,7 @@
         "sortOrder": "Descending",
         "wrapLogMessage": false
       },
-      "pluginVersion": "12.0.1",
+      "pluginVersion": "11.5.0",
       "targets": [
         {
           "datasource": {
@@ -257,7 +259,7 @@
         "sortOrder": "Descending",
         "wrapLogMessage": false
       },
-      "pluginVersion": "12.0.1",
+      "pluginVersion": "11.5.0",
       "targets": [
         {
           "datasource": {
@@ -276,7 +278,7 @@
   ],
   "preload": false,
   "refresh": "",
-  "schemaVersion": 41,
+  "schemaVersion": 40,
   "tags": ["deploy-server", "log"],
   "templating": {
     "list": []
@@ -289,5 +291,6 @@
   "timezone": "",
   "title": "LOG",
   "uid": "f0149ec2-7bf4-4d84-ab7a-131d330149fa",
-  "version": 2
+  "version": 9,
+  "weekStart": ""
 }

--- a/grafana/provisioning/dashboards/AWS/LOG.json
+++ b/grafana/provisioning/dashboards/AWS/LOG.json
@@ -71,7 +71,7 @@
         "showThresholdMarkers": false,
         "sizing": "auto"
       },
-      "pluginVersion": "10.2.3",
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
@@ -115,6 +115,7 @@
       "id": 14,
       "options": {
         "dedupStrategy": "none",
+        "enableInfiniteScrolling": false,
         "enableLogDetails": true,
         "prettifyLogMessage": false,
         "showCommonLabels": false,
@@ -123,7 +124,7 @@
         "sortOrder": "Descending",
         "wrapLogMessage": false
       },
-      "pluginVersion": "10.2.3",
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
@@ -174,9 +175,8 @@
             "type": "loki",
             "uid": "loki"
           },
-          "direction": "backward",
           "editorMode": "builder",
-          "expr": "{service_name=\"CLIENT-API\"}",
+          "expr": "{container_name=~\".*Client-Api.*\"} |= `info` !~ `(?i)Uptime-Kuma` | pattern `<_>=<ec2_instance_id> log=<log>` | logfmt --strict --keep-empty log | line_format `{{.log}}`",
           "queryType": "range",
           "refId": "A"
         }
@@ -203,6 +203,7 @@
       "id": 12,
       "options": {
         "dedupStrategy": "none",
+        "enableInfiniteScrolling": false,
         "enableLogDetails": true,
         "prettifyLogMessage": false,
         "showCommonLabels": false,
@@ -211,15 +212,16 @@
         "sortOrder": "Descending",
         "wrapLogMessage": false
       },
-      "pluginVersion": "10.2.3",
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
             "type": "loki",
             "uid": "loki"
           },
-          "editorMode": "code",
-          "expr": "{container_name=~\".*Admin-Api.*\"} |= `info` !~ `(?i)Uptime-Kuma` | pattern `<_>=<ec2_instance_id> log=<log>` | logfmt --strict --keep-empty log | line_format `{{.log}}`",
+          "direction": "backward",
+          "editorMode": "builder",
+          "expr": "{service_name=\"ADMIN-API\"} |= ``",
           "queryType": "range",
           "refId": "A"
         }
@@ -246,6 +248,7 @@
       "id": 13,
       "options": {
         "dedupStrategy": "none",
+        "enableInfiniteScrolling": false,
         "enableLogDetails": true,
         "prettifyLogMessage": false,
         "showCommonLabels": false,
@@ -254,7 +257,7 @@
         "sortOrder": "Descending",
         "wrapLogMessage": false
       },
-      "pluginVersion": "10.2.3",
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {

--- a/grafana/provisioning/dashboards/AWS/LOG.json
+++ b/grafana/provisioning/dashboards/AWS/LOG.json
@@ -178,7 +178,7 @@
           },
           "direction": "backward",
           "editorMode": "builder",
-          "expr": "{container_name=~\".*Client-Api.*\"} |= `info` !~ `(?i)Uptime-Kuma` | pattern `<_>=<ec2_instance_id> log=<log>` | logfmt --strict --keep-empty log | line_format `{{.log}}`",
+          "expr": "{service_name=\"CLIENT-API\"} !~ `(?i)Uptime-Kuma`",
           "queryType": "range",
           "refId": "A"
         }
@@ -223,7 +223,7 @@
           },
           "direction": "backward",
           "editorMode": "builder",
-          "expr": "{service_name=\"ADMIN-API\"} |= ``",
+          "expr": "{service_name=\"ADMIN-API\"} !~ `(?i)Uptime-Kuma`",
           "queryType": "range",
           "refId": "A"
         }
@@ -267,7 +267,7 @@
             "uid": "loki"
           },
           "editorMode": "builder",
-          "expr": "{container_name=~\".*Iris.*\"} |= `info` !~ `(?i)Uptime-Kuma` | pattern `<_>=<ec2_instance_id> log=<log>` | logfmt --strict --keep-empty log | line_format `{{.log}}`",
+          "expr": "{service_name=\"IRIS\"} |= `info` !~ `(?i)Uptime-Kuma` | pattern `<_>=<ec2_instance_id> log=<log>` | logfmt --strict --keep-empty log | line_format `{{.log}}`",
           "queryType": "range",
           "refId": "A"
         }


### PR DESCRIPTION
### 쿼리 수정
각 리소스(Client-API, Admin-API, IRIS)에서 Semantic Convention을 준수하는 Attribute를 사용함에 따라
조정되어야 하는 쿼리를 알맞게 수정했습니다.

### Prometheus, Loki 레이블 등록
또한 Prometheus와 Loki에 service.environment 속성을 레이블로 등록하도록 수정했습니다.
이는 [이 PR](https://github.com/skkuding/codedang/pull/2809)을 통해 IRIS에서도 전송될 것입니다.